### PR TITLE
Continuous Integration setup through Github actions

### DIFF
--- a/.github/workflows/deploy-web.yml
+++ b/.github/workflows/deploy-web.yml
@@ -30,7 +30,8 @@ jobs:
         with:
           cmd: install # will run `yarn install` command
 
-      - name: Build the static website and deploy it on gh-pages
-        uses: Borales/actions-yarn@v2.3.0
-        with:
-          cmd: deploy # will run `yarn deploy` command
+      - name: Install expo cli
+        run: |
+          npm install -g expo-cli
+          expo build:web
+          gh-pages -d web-build

--- a/.github/workflows/deploy-web.yml
+++ b/.github/workflows/deploy-web.yml
@@ -17,8 +17,6 @@ on:
 jobs:
   # This workflow contains a single job called "build"
   build:
-    # only build if the pull request was merged
-    if: github.event.pull_request.merged == true
     # The type of runner that the job will run on
     runs-on: ubuntu-latest
 

--- a/.github/workflows/deploy-web.yml
+++ b/.github/workflows/deploy-web.yml
@@ -17,6 +17,8 @@ on:
 jobs:
   # This workflow contains a single job called "build"
   build:
+    # only build if the pull request was merged
+    if: github.event.pull_request.merged == true
     # The type of runner that the job will run on
     runs-on: ubuntu-latest
 

--- a/.github/workflows/deploy-web.yml
+++ b/.github/workflows/deploy-web.yml
@@ -33,8 +33,9 @@ jobs:
       - name: Install expo cli
         run: |
           npm install -g expo-cli
+          yarn deploy
 
-      - name: Build the static website and deploy it on gh-pages
-        uses: Borales/actions-yarn@v2.3.0
-        with:
-          cmd: deploy # will run `yarn deploy` command
+      # - name: Build the static website and deploy it on gh-pages
+      #   uses: Borales/actions-yarn@v2.3.0
+      #   with:
+      #     cmd: deploy # will run `yarn deploy` command

--- a/.github/workflows/deploy-web.yml
+++ b/.github/workflows/deploy-web.yml
@@ -33,5 +33,8 @@ jobs:
       - name: Install expo cli
         run: |
           npm install -g expo-cli
-          expo build:web
-          gh-pages -d web-build
+
+      - name: Build the static website and deploy it on gh-pages
+        uses: Borales/actions-yarn@v2.3.0
+        with:
+          cmd: deploy # will run `yarn deploy` command

--- a/.github/workflows/deploy-web.yml
+++ b/.github/workflows/deploy-web.yml
@@ -30,12 +30,15 @@ jobs:
         with:
           cmd: install # will run `yarn install` command
 
-      - name: Install expo cli
+      - name: Install expo cli and build static website
         run: |
           npm install -g expo-cli
-          yarn deploy
+          expo build:web
 
-      # - name: Build the static website and deploy it on gh-pages
-      #   uses: Borales/actions-yarn@v2.3.0
-      #   with:
-      #     cmd: deploy # will run `yarn deploy` command
+      - name: Deploy on gh-pages
+        uses: crazy-max/ghaction-github-pages@v2.6.0
+        with:
+          target_branch: gh-pages
+          build_dir: web-build
+        env:
+          GITHUB_TOKEN: ${{ secrets.PERSONAL_ACCESS_TOKEN }}


### PR DESCRIPTION
This currently directly installs `expo cli` globally within the VM, which is not the recommended way to implement CI/CD in expo applications. 