### PR TITLE
Fix: GitHub Action: increased the version of the Borales action

### DIFF
--- a/.github/workflows/deploy-web.yml
+++ b/.github/workflows/deploy-web.yml
@@ -28,7 +28,7 @@ jobs:
       - uses: actions/checkout@v3
 
       - name: Install dependencies
-        uses: Borales/actions-yarn@v2.3.0
+        uses: Borales/actions-yarn@v4.2.0
         with:
           cmd: install # will run `yarn install` command
 


### PR DESCRIPTION
Increased the version of the Borales action - required to run yarn commands in GH Actions